### PR TITLE
New env var PRIV and DEV, make agent.py run based on PRIV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ render/
 *.tflite
 output/
 tf-data-models-local/
+tf-data-models/

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[FORMAT]
+max-line-length=160

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,8 @@ FROM python:3.8-slim-bullseye as python-builder
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH="${PATH}:/root/.local/bin"
 RUN apt-get update && \
-  apt-get install --no-install-recommends -y build-essential gcc git \
-  python3-pip python3-matplotlib python3-numba python3-numpy python3-venv
-COPY requirements.txt /requirements.txt
-
+  apt-get install --no-install-recommends -y build-essential gcc git python3-pip
+COPY requirements.txt /
 COPY --from=talib-builder /usr/lib/libta_lib.so.0.0.0 /usr/lib/
 RUN cd /usr/lib && ln -s libta_lib.so.0.0.0 libta_lib.so.0
 RUN cd /usr/lib && ln -s libta_lib.so.0.0.0 libta_lib.so
@@ -39,8 +37,10 @@ FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu20.04
 ENV TZ="America/Denver"
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH="${PATH}:/root/.local/bin"
+ARG PRIV
+ENV PRIV="${PRIV}"
 RUN apt-get update && \
-  apt-get install --no-install-recommends -y build-essential gcc git wget curl ca-certificates vim \
+  apt-get install --no-install-recommends -y build-essential gcc git wget curl ca-certificates vim openssh-client \
   python3.8 python3-dev python3-pip python3-distutils python3-venv pylint3 && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -59,4 +59,5 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY . /app
 WORKDIR /app
 
-CMD ["python", "/app/agent.py"]
+COPY entrypoint.sh /usr/bin/entrypoint
+ENTRYPOINT ["/usr/bin/entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN pip3 install --no-cache-dir --user -r /requirements.txt
 
 # Stage 3: Runtime
 # CUDA 11.2.2_461.33, CUDNN 8.1.1.33, tensorflow-gpu==2.9.1, tensorflow_probability==0.17.0
-FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04
 
 ENV TZ="America/Denver"
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ FROM python:3.8-slim-bullseye as python-builder
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH="${PATH}:/root/.local/bin"
 RUN apt-get update && \
-  apt-get install --no-install-recommends -y build-essential gcc git python3-pip
+  apt-get install --no-install-recommends -y build-essential gcc git python3-pip && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /
 COPY --from=talib-builder /usr/lib/libta_lib.so.0.0.0 /usr/lib/
 RUN cd /usr/lib && ln -s libta_lib.so.0.0.0 libta_lib.so.0
@@ -25,21 +26,20 @@ COPY --from=talib-builder /usr/lib/libta_lib.la /usr/lib/
 COPY --from=talib-builder /usr/lib/libta_lib.a /usr/lib/
 COPY --from=talib-builder /usr/bin/ta-lib-config /usr/bin/ta-lib-config
 COPY --from=talib-builder /usr/include/ta-lib /usr/include/ta-lib
-RUN ldconfig
 
 RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache-dir --user -r /requirements.txt
 
 # Stage 3: Runtime
-# CUDA 11.2.2_461.33, CUDNN 8.1.1.33, tensorflow-gpu==2.9.1, tensorflow_probability==0.17.0
-FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
 
 ENV TZ="America/Denver"
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH="${PATH}:/root/.local/bin"
 ARG PRIV
 ENV PRIV="${PRIV}"
-RUN apt-get update && \
+
+RUN apt-get update -y && \
   apt-get install --no-install-recommends -y build-essential gcc git wget curl ca-certificates vim openssh-client \
   python3.8 python3-dev python3-pip python3-distutils python3-venv pylint3 && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -51,10 +51,11 @@ COPY --from=talib-builder /usr/lib/libta_lib.la /usr/lib/
 COPY --from=talib-builder /usr/lib/libta_lib.a /usr/lib/
 COPY --from=talib-builder /usr/bin/ta-lib-config /usr/bin/ta-lib-config
 COPY --from=talib-builder /usr/include/ta-lib /usr/include/ta-lib
-RUN ldconfig
 COPY --from=python-builder /root/.local/lib/python3.8/site-packages /usr/local/lib/python3.8/dist-packages
+COPY --from=python-builder /root/.local/bin /usr/local/bin
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN ln -s /usr/bin/python3 /usr/local/bin/python
 
 COPY . /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 RL agent using private and shared world models
 
 Requirements:
-* Linux/Windows: CUDA Drivers installed ([compatibility matrix](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#deployment-consideration-forward))
+* Linux/Windows:
+  * 16GB free SSD storage for Nvidia environment
+  * 250Mbit/s+ internet to download Nvidia environment
+  * ~15 minutes of initial download time to install Nvidia environment
+  * Nvidia CUDA Drivers installed, 520.61.05+ ([compatibility matrix](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#deployment-consideration-forward))
 * Linux: [Docker Engine](https://docs.docker.com/engine/install/), [nvidia-docker2 installed](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker), "nvidia-smi" docker test on previous link needs to work.
 * Windows: 
   * [WSL nbody benchmark needs to work](https://docs.docker.com/desktop/windows/wsl/#gpu-support)
@@ -13,6 +17,7 @@ Requirements:
 $ git clone https://github.com/neureal/neureal-ai-agent.git
 $ cd neureal-ai-agent
 $ ./build.sh build
+...
 $ ./build.sh dev
 root@f3537fad7977:/app# time python agent.py
 ...

--- a/agent.py
+++ b/agent.py
@@ -230,6 +230,11 @@ class GeneralAI(tf.keras.Model):
                 tf.math.reduce_mean(loss['action']),
                 tf.math.reduce_mean(loss['actlog'][:,0]), tf.math.reduce_mean(loss['actlog'][:,1]),
             ]
+            
+            if self.trader:
+                del metrics[2]; metrics[2], metrics[3] = inputs['obs'][4][-1][0], env_metrics[0]
+                metrics += [inputs['obs'][0][-1][0] - outputs['obs'][0][0][0], env_metrics[1]]
+            
             dummy = tf.numpy_function(self.metrics_update, metrics, [tf.int32])
 
             if self.save_model:

--- a/agent.py
+++ b/agent.py
@@ -74,7 +74,7 @@ class GeneralAI(tf.keras.Model):
             metrics_loss['1nets*'] = {'-loss_ma':np.float64, '-loss_action':np.float64}
             metrics_loss['1extras'] = {'loss_action_returns':np.float64}
             metrics_loss['1extras2*'] = {'actlog0':np.float64, 'actlog1':np.float64}
-            
+
         for loss_group in metrics_loss.values():
             for k in loss_group.keys():
                 if k.endswith('=') or k.endswith('+'): loss_group[k] = [0 for i in range(self.max_episodes)]
@@ -230,7 +230,6 @@ class GeneralAI(tf.keras.Model):
                 tf.math.reduce_mean(loss['action']),
                 tf.math.reduce_mean(loss['actlog'][:,0]), tf.math.reduce_mean(loss['actlog'][:,1]),
             ]
-            
             dummy = tf.numpy_function(self.metrics_update, metrics, [tf.int32])
 
             if self.save_model:

--- a/agent.py
+++ b/agent.py
@@ -74,10 +74,6 @@ class GeneralAI(tf.keras.Model):
             metrics_loss['1nets*'] = {'-loss_ma':np.float64, '-loss_action':np.float64}
             metrics_loss['1extras'] = {'loss_action_returns':np.float64}
             metrics_loss['1extras2*'] = {'actlog0':np.float64, 'actlog1':np.float64}
-        if self.trader:
-            metrics_loss['2rewards*'] = {'-equity_final=':np.float64, '-draw_total':np.float64}
-            metrics_loss['1trader_sim_time'] = {'sim_time_secs':np.float64}
-            metrics_loss['1trader_draws'] = {'-drawdown_total':np.float64}
             
         for loss_group in metrics_loss.values():
             for k in loss_group.keys():
@@ -234,10 +230,6 @@ class GeneralAI(tf.keras.Model):
                 tf.math.reduce_mean(loss['action']),
                 tf.math.reduce_mean(loss['actlog'][:,0]), tf.math.reduce_mean(loss['actlog'][:,1]),
             ]
-            
-            if self.trader:
-                del metrics[2]; metrics[2], metrics[3] = inputs['obs'][4][-1][0], env_metrics[0]
-                metrics += [inputs['obs'][0][-1][0] - outputs['obs'][0][0][0], env_metrics[1]]
             
             dummy = tf.numpy_function(self.metrics_update, metrics, [tf.int32])
 

--- a/agent.py
+++ b/agent.py
@@ -70,11 +70,15 @@ class GeneralAI(tf.keras.Model):
         metrics_loss = OrderedDict()
         metrics_loss['2rewards*'] = {'-rewards_ma':np.float64, '-rewards_total+':np.float64, 'rewards_final=':np.float64}
         metrics_loss['1steps'] = {'steps+':np.int64}
-        if arch == 'PG':
+        if self.arch == 'PG':
             metrics_loss['1nets*'] = {'-loss_ma':np.float64, '-loss_action':np.float64}
             metrics_loss['1extras'] = {'loss_action_returns':np.float64}
             metrics_loss['1extras2*'] = {'actlog0':np.float64, 'actlog1':np.float64}
-
+        if self.trader:
+            metrics_loss['2rewards*'] = {'-equity_final=':np.float64, '-draw_total':np.float64}
+            metrics_loss['1trader_sim_time'] = {'sim_time_secs':np.float64}
+            metrics_loss['1trader_draws'] = {'-drawdown_total':np.float64}
+            
         for loss_group in metrics_loss.values():
             for k in loss_group.keys():
                 if k.endswith('=') or k.endswith('+'): loss_group[k] = [0 for i in range(max_episodes)]

--- a/agent.py
+++ b/agent.py
@@ -256,9 +256,16 @@ device_type = 'CPU'
 machine, device, extra = 'dev', 0, ''
 
 trader, env_async, env_async_clock, env_async_speed, env_reconfig, chart_lim = False, False, 0.001, 160.0, False, 0.003
-env_name, max_steps, env_render, env_reconfig, env = 'CartPole', 256, False, True, gym.make('CartPole-v0') # (4) float32    ()2 int64    200  195.0
-# env_name, max_steps, env_render, env_reconfig, env = 'CartPole', 512, False, True, gym.make('CartPole-v1') # (4) float32    ()2 int64    500  475.0
-# env_name, max_steps, env_render, env_reconfig, env = 'LunarLand', 1024, False, True, gym.make('LunarLander-v2') # (8) float32    ()4 int64    1000  200
+
+gym_make = 'CartPole-v0'
+if os.environ['PRIV'] == '1':
+    from gym_trader.envs import TraderEnv; tenv = 4; env_name, max_steps, env_render, env, trader, chart_lim = 'Trader'+str(tenv), 256, False, TraderEnv(agent_id=device, env=tenv), True, 0.0; extra += "-rs{}-td{}-s{}-dd{}".format(env.NUM_EPISODES,int(env.TIMEDELTA_RANGE),int(env.MAX_EPISODE_TIME/env.TIMEDELTA_RANGE),int(env.START_TARGET_BAL))
+elif gym_make == 'CartPole-v0':
+    env_name, max_steps, env_render, env_reconfig, env = 'CartPole', 256, False, True, gym.make('CartPole-v0') # (4) float32    ()2 int64    200  195.0
+elif gym_make == 'CartPole-v1':
+    env_name, max_steps, env_render, env_reconfig, env = 'CartPole', 512, False, True, gym.make('CartPole-v1') # (4) float32    ()2 int64    500  475.0
+elif gym_make == 'LunarLander-v2':
+    env_name, max_steps, env_render, env_reconfig, env = 'LunarLand', 1024, False, True, gym.make('LunarLander-v2') # (8) float32    ()4 int64    1000  200
 
 arch = 'PG'; learn_rates = {'action':4e-6} # Policy Gradient agent, PG loss
 

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -eu
 
 CWD=$(basename "$PWD")
 export DEV=1
+export MT5IP
 
 build() {
     docker build . --tag "$CWD"
@@ -26,7 +27,7 @@ dev() {
 	-e DEV \
 	-e MT5IP \
         -v "$PWD"/output:/app/output \
-        -v "$PWD"/tf-data-models-local:/app/tf-data-models-local \
+        -v "$PWD"/tf-data-models-local:/root/tf-data-models-local \
         -v "$PWD"/tf-data-models:/root/tf-data-models \
 	-v "$PWD"/..:/outerdir \
         -p 8080:8080 \

--- a/build.sh
+++ b/build.sh
@@ -21,10 +21,12 @@ clean() {
 dev() {
     mkdir -p output
     mkdir -p tf-data-models-local
+    mkdir -p tf-data-models
     docker run --rm --gpus=all \
 	-e DEV \
         -v "$PWD"/output:/app/output \
         -v "$PWD"/tf-data-models-local:/app/tf-data-models-local \
+        -v "$PWD"/tf-data-models:/root/tf-data-models \
 	-v "$PWD"/..:/outerdir \
         -p 8080:8080 \
         -it "$CWD" "$@"

--- a/build.sh
+++ b/build.sh
@@ -24,13 +24,12 @@ dev() {
     mkdir -p tf-data-models-local
     mkdir -p tf-data-models
     docker run --rm --gpus=all \
-	    -e DEV \
-	    -e MT5IP \
+        -e DEV \
+        -e MT5IP \
         -v "$PWD"/output:/app/output \
         -v "$PWD"/tf-data-models-local:/root/tf-data-models-local \
         -v "$PWD"/tf-data-models:/root/tf-data-models \
-	    -v "$PWD"/..:/outerdir \
-        -p 8080:8080 \
+        -v "$PWD"/..:/outerdir \
         -it "$CWD" "$@"
 }
 

--- a/build.sh
+++ b/build.sh
@@ -23,12 +23,12 @@ dev() {
     mkdir -p tf-data-models-local
     mkdir -p tf-data-models
     docker run --rm --gpus=all \
-	-e DEV \
-	-e MT5IP \
+	    -e DEV \
+	    -e MT5IP \
         -v "$PWD"/output:/app/output \
         -v "$PWD"/tf-data-models-local:/app/tf-data-models-local \
         -v "$PWD"/tf-data-models:/root/tf-data-models \
-	-v "$PWD"/..:/outerdir \
+	    -v "$PWD"/..:/outerdir \
         -p 8080:8080 \
         -it "$CWD" "$@"
 }

--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,7 @@ dev() {
     mkdir -p tf-data-models
     docker run --rm --gpus=all \
 	-e DEV \
+	-e MT5IP \
         -v "$PWD"/output:/app/output \
         -v "$PWD"/tf-data-models-local:/app/tf-data-models-local \
         -v "$PWD"/tf-data-models:/root/tf-data-models \

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,9 @@
-#!/bin/sh
+#!/usr/bin/bash
 
 set -eu
 
 CWD=$(basename "$PWD")
 export DEV=1
-export MT5IP
 
 build() {
     docker build . --tag "$CWD"
@@ -20,16 +19,23 @@ clean() {
 }
 
 dev() {
+    # TF_* vars: https://docs.nvidia.com/deeplearning/frameworks/tensorflow-user-guide/index.html#tensorcore
     mkdir -p output
+    mkdir -p logs
     mkdir -p tf-data-models-local
     mkdir -p tf-data-models
     docker run --rm --gpus=all \
         -e DEV \
         -e MT5IP \
+        -e TF_ENABLE_CUBLAS_TENSOR_OP_MATH_FP32=1 \
+        -e TF_ENABLE_CUDNN_TENSOR_OP_MATH_FP32=1 \
+        -e TF_ENABLE_CUDNN_RNN_TENSOR_OP_MATH_FP32=1 \
         -v "$PWD"/output:/app/output \
+        -v "$PWD"/logs:/app/logs \
         -v "$PWD"/tf-data-models-local:/root/tf-data-models-local \
         -v "$PWD"/tf-data-models:/root/tf-data-models \
         -v "$PWD"/..:/outerdir \
+	-p 6006:6006 \
         -it "$CWD" "$@"
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,14 @@
 [ $PRIV ] && pip3 install --user -e /outerdir/neureal-ai-interfaces
 [ $PRIV ] && pip3 install --user -e /outerdir/neureal-ai-util
 
-#TEMPORARY
-pip install mt5linux
+if [ $PRIV ]
+then
+  cd /outerdir/neureal-ai-agent
+  /usr/local/bin/tensorboard --bind_all --port 6006 --logdir /outerdir/neureal-ai-agent/logs serve &
+else
+  cd /app
+  /usr/local/bin/tensorboard --bind_all --port 6006 --logdir /app/logs serve &
+fi
 
 [ $DEV ] && exec bash
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+#pip3 install --user gym-trader@git+ssh://git@github.com/wilbown/gym-trader.git
+#pip3 install --user neureal-ai-interfaces@git+ssh://git@github.com/wilbown/neureal-ai-interfaces.git
+[ $PRIV ] && pip3 install --user -e /outerdir/gym-trader
+[ $PRIV ] && pip3 install --user -e /outerdir/neureal-ai-interfaces
+
+[ $DEV ] && exec bash
+
+/usr/bin/python /app/agent.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,9 @@
 
 [ $DEV ] && exec bash
 
-/usr/bin/python /app/agent.py
+if [ $PRIV ]
+then
+  /usr/bin/python /app/agent_research.py
+else
+  /usr/bin/python /app/agent.py
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,9 +7,12 @@
 
 [ $DEV ] && exec bash
 
+#TEMPORARY
+pip install mt5linux
+
 if [ $PRIV ]
 then
-  /usr/bin/python /app/agent_research.py
+  /usr/bin/python /outerdir/neureal-ai-agent/agent_research.py
 else
   /usr/bin/python /app/agent.py
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
-#pip3 install --user gym-trader@git+ssh://git@github.com/wilbown/gym-trader.git
-#pip3 install --user neureal-ai-interfaces@git+ssh://git@github.com/wilbown/neureal-ai-interfaces.git
 [ $PRIV ] && pip3 install --user -e /outerdir/gym-trader
 [ $PRIV ] && pip3 install --user -e /outerdir/neureal-ai-interfaces
-
-[ $DEV ] && exec bash
+[ $PRIV ] && pip3 install --user -e /outerdir/neureal-ai-util
 
 #TEMPORARY
 pip install mt5linux
+
+[ $DEV ] && exec bash
 
 if [ $PRIV ]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,10 +7,10 @@
 if [ $PRIV ]
 then
   cd /outerdir/neureal-ai-agent
-  /usr/local/bin/tensorboard --bind_all --port 6006 --logdir /outerdir/neureal-ai-agent/logs serve &
+#  /usr/local/bin/tensorboard --bind_all --port 6006 --logdir /outerdir/neureal-ai-agent/logs serve &
 else
   cd /app
-  /usr/local/bin/tensorboard --bind_all --port 6006 --logdir /app/logs serve &
+#  /usr/local/bin/tensorboard --bind_all --port 6006 --logdir /app/logs serve &
 fi
 
 [ $DEV ] && exec bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gym==0.23.1  # Do not increase past 0.23.1 until this is live: https://github.co
 gym-algorithmic==0.0.1
 keyboard==0.13.5
 matplotlib==3.6.0
-#mt5linux   #can't be installed by pip this way, yet. requirements.txt bug in their repo.
+mt5linux @ git+https://github.com/lucas-campagna/mt5linux.git    #can't be installed directly yet. requirements.txt bug in their repo.
 neureal-ai-util @ git+https://github.com/neureal/neureal-ai-util.git
 numba==0.56.2
 pandas==1.5.0
@@ -14,7 +14,7 @@ pybullet==3.2.5
 pygame==2.1.2
 pyglet==1.5.27
 pyzmq==24.0.1
-tensorflow-gpu==2.10.0
-tensorflow_addons==0.18.0
-tensorflow_datasets==4.7.0
-tensorflow_probability==0.18.0
+tensorflow-gpu==2.9.2 # Waiting for https://github.com/tensorflow/tensorflow/pull/56691 to be merged fully (cuBLAS error)
+tensorflow_addons==0.17.0
+tensorflow_datasets==4.6.0
+tensorflow_probability==0.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gym==0.23.1  # Do not increase past 0.23.1 until this is live: https://github.co
 gym-algorithmic==0.0.1
 keyboard==0.13.5
 matplotlib==3.6.0
-mt5linux @ git+https://github.com/james-coder/mt5linux.git
+mt5linux
 neureal-ai-util @ git+https://github.com/neureal/neureal-ai-util.git
 numba==0.56.2
 pandas==1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gym==0.23.1  # Do not increase past 0.23.1 until this is live: https://github.co
 gym-algorithmic==0.0.1
 keyboard==0.13.5
 matplotlib==3.6.0
-mt5linux
+#mt5linux   #can't be installed by pip this way, yet. requirements.txt bug in their repo.
 neureal-ai-util @ git+https://github.com/neureal/neureal-ai-util.git
 numba==0.56.2
 pandas==1.5.0
@@ -13,7 +13,7 @@ procgen==0.10.7
 pybullet==3.2.5
 pygame==2.1.2
 pyglet==1.5.27
-tensorflow-gpu==2.9.1
+tensorflow-gpu==2.10.0
 tensorflow_addons==0.18.0
-tensorflow_datasets==4.6.0
-tensorflow_probability==0.17.0
+tensorflow_datasets==4.7.0
+tensorflow_probability==0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ procgen==0.10.7
 pybullet==3.2.5
 pygame==2.1.2
 pyglet==1.5.27
+pyzmq==24.0.1
 tensorflow-gpu==2.9.1
 tensorflow_addons==0.18.0
 tensorflow_datasets==4.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,10 @@ gym==0.23.1  # Do not increase past 0.23.1 until this is live: https://github.co
 gym-algorithmic==0.0.1
 keyboard==0.13.5
 matplotlib==3.6.0
+mt5linux @ git+https://github.com/james-coder/mt5linux.git
 neureal-ai-util @ git+https://github.com/neureal/neureal-ai-util.git
 numba==0.56.2
+pandas==1.5.0
 procgen==0.10.7
 pybullet==3.2.5
 pygame==2.1.2


### PR DESCRIPTION
There is a new way to run this:
`$ ./build.sh buildpriv`

This uses the same local tag name, but builds with environment variable PRIV=1.

This does: (in entrypoint.sh)
```
pip3 install --user -e /outerdir/gym-trader
pip3 install --user -e /outerdir/neureal-ai-interfaces
```

If you have your neureal directories set up like this: (outside of docker)
```
$ ls
neureal-ai-agent  neureal-ai-interfaces gym-trader
```

Then, it can do the `pip -e` Development Mode.

With PRIV not set to 1, then agent.py works in the Public repo way.

DEV is used to reuse code for `./build.sh dev` and `./build.sh run`